### PR TITLE
WIP: Making manual schedule maker

### DIFF
--- a/Jolly-Lights-Cinema-Group/BusinessLogic/AdminHandler/AdminChoiceHandler.cs
+++ b/Jolly-Lights-Cinema-Group/BusinessLogic/AdminHandler/AdminChoiceHandler.cs
@@ -29,7 +29,7 @@ namespace Jolly_Lights_Cinema_Group
                     ShopManagementHandler.ManageShopManagement();
                     break;
                 case 5:
-                    ViewReports();
+                    MovieScheduleHandler.ScheduleMovies();
                     break;
                 case 6:
                     AccountSettingsHandler.ManageAccount();

--- a/Jolly-Lights-Cinema-Group/BusinessLogic/AdminHandler/AdminMovieHandler.cs
+++ b/Jolly-Lights-Cinema-Group/BusinessLogic/AdminHandler/AdminMovieHandler.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.CompilerServices;
 using System.Xml.Serialization;
+using JollyLightsCinemaGroup.DataAccess;
 
 namespace Jolly_Lights_Cinema_Group
 {
@@ -54,6 +55,7 @@ namespace Jolly_Lights_Cinema_Group
                 Console.WriteLine("who are in the movie cast?");
                 string MovieCast = Console.ReadLine()!;
 
+                Console.Clear();
                 Console.WriteLine("Are you ready to add the next movie to the database?\ny/n or e for exit: ");
                 Console.WriteLine($"Title: {Title}\nDuration: {Duration}\nMinimum Age: {MinimumAge}\nReleaseDate: {ReleaseDate}\nMoviecast: {MovieCast}");
                 Console.Write("Answer: ");
@@ -88,6 +90,7 @@ namespace Jolly_Lights_Cinema_Group
             movieservice.ShowAllMovies();
             Console.ReadKey();
         }
+
     }
 
 }

--- a/Jolly-Lights-Cinema-Group/BusinessLogic/GlobalHandlers/ScheduleManagerHandler.cs
+++ b/Jolly-Lights-Cinema-Group/BusinessLogic/GlobalHandlers/ScheduleManagerHandler.cs
@@ -1,0 +1,157 @@
+using System.Data.Common;
+using System.Reflection;
+using JollyLightsCinemaGroup.DataAccess;
+
+namespace Jolly_Lights_Cinema_Group
+{
+    public static class MovieScheduleHandler
+    {
+        public static void ScheduleMovies()
+        {
+            bool inScheduleMovies = true;
+            ScheduleMenu schedulemenu = new();
+            Console.Clear();
+
+            while (inScheduleMovies)
+            {
+                int userChoice = schedulemenu.Run();
+                inScheduleMovies = HandleManageScheduleMenu(userChoice);
+                Console.Clear();
+            }
+        }
+        private static bool HandleManageScheduleMenu(int choice)
+        {
+            switch (choice)
+            {
+                case 0:
+                    AddScheduleline();
+                    return true;
+                case 1:
+                    Console.WriteLine("Choice2");
+                    return true;
+                case 2:
+                    return true;
+                case 3:
+                    return true;
+                case 4:
+                    return false;
+                default:
+                    Console.WriteLine("Invalid selection.");
+                    return true;
+            }
+        }
+
+        // adding movie schedule (making)  -- Movieroom (based on ID),moviename (based on id),startdate
+        private static void AddScheduleline()
+        {
+            Console.Clear();
+            // Testdata for room: (next update has to come from DB)
+            MovieRoom TestDataForMovieRoom = new(id: 1, roomNumber: 1, roomLayoutJson: "aa", supportedMovieType: 1, locationId: 1);
+
+            ScheduleService scheduleservice = new();
+
+            // Adding MovieId
+            Movie? selectedMovie = null;
+            do
+            {
+                Console.WriteLine("From the movie DB, What movie do you want to add? (Title or MovieId)");
+                string? input = Console.ReadLine();
+
+                if (int.TryParse(input, out int movieId))
+                {
+                    selectedMovie = MovieRepository.GetMovieById(movieId);
+                    if (selectedMovie != null)
+                    {
+                        Console.WriteLine($"Movie selected: {selectedMovie.Title}");
+                    }
+                    else
+                    {
+                    }
+                }
+                else if (!string.IsNullOrWhiteSpace(input))
+                {
+                    selectedMovie = MovieRepository.GetMovieByTitle(input);
+                    if (selectedMovie != null)
+                    {
+                        Console.WriteLine($"Movie selected: {selectedMovie.Title}");
+                    }
+                    else
+                    {
+                        Console.WriteLine("Movie not found. Please try again.");
+                    }
+                }
+                else
+                {
+                    Console.WriteLine("Invalid input. Please enter a valid movie title or ID.");
+                }
+            } while (selectedMovie == null);
+
+
+            // Adding RoomNumber
+            int roomNumber = -1;
+            do
+            {
+                Console.WriteLine("In what room will it play? (Index of available rooms)");
+                string? roomInput = Console.ReadLine();
+                if (int.TryParse(roomInput, out roomNumber))
+                {
+                    break;
+                }
+                else
+                {
+                    Console.WriteLine("Invalid input. Please enter a valid room number.");
+                }
+            } while (roomNumber < 0);
+
+            // Adding StartDate
+            DateTime startDate;
+            do
+            {
+                Console.WriteLine("What is the start date? (dd/MM/yyyy)");
+                string? inputDate = Console.ReadLine();
+                if (DateTime.TryParseExact(inputDate, "dd/MM/yyyy",
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.None,
+                    out startDate))
+                {
+                    break;
+                }
+                else
+                {
+                    Console.WriteLine("Invalid format. Please use dd/MM/yyyy (e.g., 09/05/2025).");
+                }
+            } while (true);
+
+            // Adding StartTime
+            TimeSpan startTime;
+            do
+            {
+                Console.WriteLine("What is the start time? (HH:mm:ss)");
+                string? inputTime = Console.ReadLine();
+                if (TimeSpan.TryParseExact(inputTime, "hh\\:mm\\:ss",
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out startTime))
+                {
+                    break;
+                }
+                else
+                {
+                    Console.WriteLine("Invalid format. Please use HH:mm:ss (e.g., 14:30:00).");
+                }
+            } while (true);
+
+            Schedule schedule = new(roomNumber, selectedMovie.Id.Value, startDate, startTime);
+            scheduleservice.RegisterSchedule(schedule);
+            Console.ReadKey();
+        }
+
+
+        // deleting schedule (delete)
+
+        // show schedule
+
+        // Automatic schedule
+
+
+    }
+}

--- a/Jolly-Lights-Cinema-Group/BusinessLogic/ScheduleService.cs
+++ b/Jolly-Lights-Cinema-Group/BusinessLogic/ScheduleService.cs
@@ -10,10 +10,50 @@ public class ScheduleService
     {
         _scheduleRepo = new ScheduleRepository();
     }
-    public void RegisterSchedule(int movieRoomId, int movieId, DateTime startDate)
+
+    // Adding Schedule. Also checks if time is not overlapping other times of movies. 
+    // Cleaning time is not yet included.
+    public void RegisterSchedule(Schedule schedule)
     {
-        _scheduleRepo.AddSchedule(movieRoomId, movieId, startDate);
+        bool canAdd = _scheduleRepo.CanAddSchedule(
+            schedule.MovieRoomId,
+            schedule.StartDate,
+            schedule.StartTime
+        );
+
+        if (!canAdd)
+        {
+            Console.WriteLine("Schedule overlaps with another movie in the same room.");
+            return;
+        }
+
+        bool scheduleAdded = _scheduleRepo.AddSchedule(schedule);
+        if (scheduleAdded)
+        {
+            Console.WriteLine("Movie schedule successfully added!");
+            _scheduleRepo.UpdateFreeTimeColumn();
+        }
+        else
+        {
+            Console.WriteLine("Something went wrong while adding the schedule.");
+        }
+    }
+
+
+    // Deleting (based on movieid and startdate)
+    public void DeleteSchedule(Schedule schedule)
+    {
+        Console.WriteLine();
+    }
+
+    // Show Schedule
+
+    public void ShowSchedule(DateTime dateTime)
+    {
+        Console.WriteLine();
     }
 }
 
 // Should we add a check for checking if id's are valid? I think so, but this can be added later
+
+// 

--- a/Jolly-Lights-Cinema-Group/DataAccess/MovieRepository.cs
+++ b/Jolly-Lights-Cinema-Group/DataAccess/MovieRepository.cs
@@ -26,32 +26,65 @@ namespace JollyLightsCinemaGroup.DataAccess
             }
         }
 
-        public Movie? GetMovieByTitle(Movie movie)
+        public static Movie? GetMovieById(int index)
         {
             using (var connection = DatabaseManager.GetConnection())
             {
                 connection.Open();
                 var command = connection.CreateCommand();
                 command.CommandText = @"
-                SELECT Title, Duration, MinimunAge, ReleaseDate, MovieCast FROM Movie
-                WHERE Title = @Title;";
+                SELECT Id, Title, Duration, MinimunAge, ReleaseDate, MovieCast FROM Movie
+                WHERE Id = @Id;";
 
-                command.Parameters.AddWithValue("@Title", movie.Title);
+                command.Parameters.AddWithValue("@Id", index);
 
                 using (var reader = command.ExecuteReader())
                 {
                     if (reader.Read())
                     {
                         return new Movie(
-                            reader.GetString(0), // Title
-                            reader.GetInt32(1),  // Duration
-                            reader.GetInt32(2),  // MinimunAge
-                            reader.GetDateTime(3), // ReleaseDate
-                            reader.GetString(4)  // MovieCast
+                            reader.GetInt32(0), // id
+                            reader.GetString(1), // Title
+                            reader.GetInt32(2),  // Duration
+                            reader.GetInt32(3),  // MinimunAge
+                            reader.GetDateTime(4), // ReleaseDate
+                            reader.GetString(5)  // MovieCast
                         );
                     }
                 }
             }
+            Console.WriteLine("Movie with this ID not found.");
+            return null;
+        }
+
+        public static Movie? GetMovieByTitle(string Title)
+        {
+            using (var connection = DatabaseManager.GetConnection())
+            {
+                connection.Open();
+                var command = connection.CreateCommand();
+                command.CommandText = @"
+                SELECT Id, Title, Duration, MinimunAge, ReleaseDate, MovieCast FROM Movie
+                WHERE Title = @Title;";
+
+                command.Parameters.AddWithValue("@Title", Title);
+
+                using (var reader = command.ExecuteReader())
+                {
+                    if (reader.Read())
+                    {
+                        return new Movie(
+                            reader.GetInt32(0), // id
+                            reader.GetString(1), // Title
+                            reader.GetInt32(2),  // Duration
+                            reader.GetInt32(3),  // MinimunAge
+                            reader.GetDateTime(4), // ReleaseDate
+                            reader.GetString(5)  // MovieCast
+                        );
+                    }
+                }
+            }
+            Console.WriteLine("Movie with this Title not found.");
             return null;
         }
 

--- a/Jolly-Lights-Cinema-Group/DataAccess/ScheduleRepository.cs
+++ b/Jolly-Lights-Cinema-Group/DataAccess/ScheduleRepository.cs
@@ -1,28 +1,81 @@
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.Sqlite;  
+using Microsoft.Data.Sqlite;
 
 namespace JollyLightsCinemaGroup.DataAccess
 {
     public class ScheduleRepository
     {
-        public void AddSchedule(int movieRoomId, int movieId, DateTime startDate)
+        public bool AddSchedule(Schedule schedule)
         {
             using (var connection = DatabaseManager.GetConnection())
             {
                 connection.Open();
                 var command = connection.CreateCommand();
                 command.CommandText = @"
-                    INSERT INTO Schedule (MovieRoomId, MovieId, StartDate)
-                    VALUES (@movieRoomId, @movieId, @startDate);";
+                    INSERT INTO Schedule (MovieRoomId, MovieId, StartDate, StartTime)
+                    VALUES (@movieRoomId, @movieId, @startDate,@startTime);";
 
-                command.Parameters.AddWithValue("@movieRoomId", movieRoomId);
-                command.Parameters.AddWithValue("@movieId", movieId);
-                command.Parameters.AddWithValue("@startDate", startDate);
+                command.Parameters.AddWithValue("@movieRoomId", schedule.MovieRoomId);
+                command.Parameters.AddWithValue("@movieId", schedule.MovieId);
+                command.Parameters.AddWithValue("@startDate", schedule.StartDate);
+                command.Parameters.AddWithValue("@startTime", schedule.StartTime);
+
+                return command.ExecuteNonQuery() > 0;
+            }
+        }
+
+        public void UpdateFreeTimeColumn()
+        {
+            using (var connection = DatabaseManager.GetConnection())
+            {
+                connection.Open();
+                var command = connection.CreateCommand();
+                command.CommandText = @"
+                    UPDATE Schedule
+                    SET FreeAfter = time(StartTime, '+' || (SELECT Duration + 15 FROM Movie WHERE Id = Schedule.MovieId) || ' minutes')
+                    WHERE EXISTS (SELECT 1 FROM Movie WHERE Id = Schedule.MovieId);";
 
                 command.ExecuteNonQuery();
-                Console.WriteLine("Schedule added successfully.");
+            }
+        }
+
+        public bool CanAddSchedule(int roomId, DateTime startDate, TimeSpan startTime)
+        {
+            using (var connection = DatabaseManager.GetConnection())
+            {
+                connection.Open();
+                var command = connection.CreateCommand();
+                command.CommandText = @"
+                    SELECT COUNT(*)
+                    FROM Schedule
+                    WHERE MovieRoomId = @roomId
+                    AND StartDate = @startDate
+                    AND @startTime < FreeAfter";
+
+                command.Parameters.AddWithValue("@roomId", roomId);
+                command.Parameters.AddWithValue("@startDate", startDate);
+                command.Parameters.AddWithValue("@startTime", startTime);
+
+                var count = Convert.ToInt32(command.ExecuteScalar());
+                return count == 0;
+            }
+        }
+
+        public int GetMovieDuration(int movieId)
+        {
+            using (var connection = DatabaseManager.GetConnection())
+            {
+                connection.Open();
+                var command = connection.CreateCommand();
+                command.CommandText = "SELECT Duration FROM Movie WHERE Id = @movieId;";
+                command.Parameters.AddWithValue("@movieId", movieId);
+
+                var result = command.ExecuteScalar();
+                return result != null ? Convert.ToInt32(result) : 0;
             }
         }
     }
+
+
 }

--- a/Jolly-Lights-Cinema-Group/Database/schema.sql
+++ b/Jolly-Lights-Cinema-Group/Database/schema.sql
@@ -40,10 +40,24 @@ CREATE TABLE IF NOT EXISTS Schedule (
   Id INTEGER PRIMARY KEY AUTOINCREMENT,
   MovieRoomId INTEGER NOT NULL,
   MovieId INTEGER NOT NULL,
-  StartDate DATETIME NOT NULL,
+  StartDate DATE NOT NULL,
+  StartTime TIME NOT NULL,
+  FreeAfter DATETIME,
   FOREIGN KEY (MovieRoomId) REFERENCES MovieRoom (Id) ON DELETE CASCADE,
   FOREIGN KEY (MovieId) REFERENCES Movie (Id) ON DELETE CASCADE
 );
+
+-- trigger to update FreeAfter column after a schedule is inserted --
+CREATE TRIGGER AfterInsertSchedule
+AFTER INSERT ON Schedule
+FOR EACH ROW
+BEGIN
+    UPDATE Schedule
+    SET FreeAfter = datetime(NEW.StartDate || ' ' || NEW.StartTime, '+' || 
+                              (SELECT Duration FROM Movie WHERE Id = NEW.MovieId) || ' minutes')
+    WHERE Id = NEW.Id;
+END;
+-----------------------------------------------------------------------------
 
 CREATE TABLE IF NOT EXISTS Reservation (
   Id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/Jolly-Lights-Cinema-Group/Models/Schedule.cs
+++ b/Jolly-Lights-Cinema-Group/Models/Schedule.cs
@@ -1,19 +1,21 @@
-class Schedule
+public class Schedule
 {
     public int? Id { get; set; }
     public int MovieRoomId { get; set; }
     public int MovieId { get; set; }
     public DateTime StartDate { get; set; }
+    public TimeSpan StartTime { get; set; }
 
-    public Schedule(int movieRoomId, int movieId, DateTime startDate)
+    public Schedule(int movieRoomId, int movieId, DateTime startDate, TimeSpan startTime)
     {
         MovieRoomId = movieRoomId;
         MovieId = movieId;
         StartDate = startDate;
+        StartTime = startTime;
     }
 
-    public Schedule(int id, int movieRoomId, int movieId, DateTime startDate)
-        : this(movieRoomId, movieId, startDate)
+    public Schedule(int id, int movieRoomId, int movieId, DateTime startDate, TimeSpan startTime)
+        : this(movieRoomId, movieId, startDate, startTime)
     {
         Id = id;
     }

--- a/Jolly-Lights-Cinema-Group/PresentationLayer/Admin/AdminMenu.cs
+++ b/Jolly-Lights-Cinema-Group/PresentationLayer/Admin/AdminMenu.cs
@@ -4,7 +4,7 @@ namespace Jolly_Lights_Cinema_Group
     public class AdminMenu : Menu
     {
 
-        public AdminMenu() : base("Admin Menu", new string[] { "Manage Reservations", "Manage Users", "Manage Locations", "Manage Movies", "Manage shop", "View Reports", "Settings", "Logout" }) { }
+        public AdminMenu() : base("Admin Menu", new string[] { "Manage Reservations", "Manage Users", "Manage Locations", "Manage Movies", "Manage shop", "Manage Movie Schedule", "Settings", "Logout" }) { }
 
     }
 }

--- a/Jolly-Lights-Cinema-Group/PresentationLayer/Admin/ManageScheduleMenu.cs
+++ b/Jolly-Lights-Cinema-Group/PresentationLayer/Admin/ManageScheduleMenu.cs
@@ -1,0 +1,10 @@
+
+namespace Jolly_Lights_Cinema_Group
+{
+    public class ScheduleMenu : Menu
+    {
+
+        public ScheduleMenu() : base("Schedule Menu", new string[] { "Daily Manual planning", "Deleting planning", "Show Planning of today", "Automatic planning (Coming soon)", "Back" }) { }
+
+    }
+}


### PR DESCRIPTION
Because of upcoming deadlines, I’m opening a PR for this push even though it’s still a Work In Progress (WIP). The core functionality is nearly complete.

Summary of changes:
- Updated the Schedule database structure:
  -- Added new columns: StartTime and FreeAfter.
- Extended the Schedule object to include StartTime.
- Implemented an automatic update function that recalculates the FreeAfter time — this simplifies determining when the next movie can be scheduled.
- Added a CanAdd function to check whether a new movie can be added without causing time conflicts or overlaps.
- Integrated the new features into the admin menu with appropriate handlers.

Next steps (not yet included in this PR):
Implement a delete function for schedules.

Add functionality to display the full schedule for a given date.

Both next steps are relatively small, as ~80% of the supporting code is already in place.


After all this is done, we can take a look at the automatic version.
![afbeelding_2025-05-09_220230492](https://github.com/user-attachments/assets/a9357c54-40b3-489f-9e48-04df26a22cd0)
